### PR TITLE
explicit args for plot revised

### DIFF
--- a/R/Tracks-methods.R
+++ b/R/Tracks-methods.R
@@ -210,15 +210,11 @@ setMethod("plot", "TracksCollection",
 			ylim = stbox(x)[,2], col = 1, lwd = 1, lty =
 			1, axes = TRUE, Arrows = FALSE, Segments = FALSE, add = FALSE) {
 		sp = x@tracksCollection[[1]]@tracks[[1]]@sp
-		if (! add) {
-                        a <- as.list (match.call ())
-                        a <- a [which (names (a) %in% 
-                                       names (c (par (), formals (plot.default))))]
-                        a <- a [3:length (a)] # [[1]]=the call, [[2]]=x
-                        a <- c (as (x, "Spatial"), a)
-                        do.call (plot, a)
-			#plot(as(sp, "Spatial"), xlim = xlim, ylim = ylim, axes = axes, ...)
-                }
+                # Submitting arrows formals to plot prompts warnings, so they
+                # are removed here.
+                aplot <- function (..., length, angle, code) plot (...)
+		if (! add)
+			aplot(as(sp, "Spatial"), xlim = xlim, ylim = ylim, axes = axes, ...)
 		if (axes == FALSE)
 			box()
 		if (Arrows || Segments) {


### PR DESCRIPTION
> library (trajectories)
> example (Track)
> plot (Tr, Arrows=T, length=0.1) # or other formals(arrows), "angle" or "code"

Warning messages:
1: In plot.window(xlim = xlim, ylim = ylim, asp = asp, ...) :
  "length" is not a graphical parameter
2: In axis(side, at = at, labels = labels, ...) :
  "length" is not a graphical parameter
3: In axis(side, at = at, labels = labels, ...) :
  "length" is not a graphical parameter

Warnings removed by passing all arguments through another dummy function ("aplot") with formals (arrows) specified to strip them from (...), so subsequent passing to plot no longer prompts warnings.
